### PR TITLE
Fix dynamic loading inference-module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project(scl-machine VERSION 0.3.0 LANGUAGES C CXX)
 message(STATUS "Current project version: ${CMAKE_PROJECT_VERSION}")
 cmake_policy(SET CMP0048 NEW)
 
+if(${WIN32})
+    message(FATAL_ERROR "scl-machine isn't supported on Windows OS.")
+endif()
+
 set(SCL_MACHINE_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
@@ -33,10 +37,6 @@ endif()
 
 if(${SC_CLANG_FORMAT_CODE})
     include(${CMAKE_MODULE_PATH}/ClangFormat.cmake)
-endif()
-
-if(${WIN32})
-    message(FATAL_ERROR "scl-machine isn't supported on Windows OS.")
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,5 +1,5 @@
 install(TARGETS 
-    inference
+    inference-object inference
     EXPORT scl-machineExport
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/problem-solver/cxx/inference-module/CMakeLists.txt
+++ b/problem-solver/cxx/inference-module/CMakeLists.txt
@@ -5,12 +5,12 @@ file(GLOB SOURCES CONFIGURE_DEPENDS
     "lib/src/*/*/*.hpp" "lib/src/*/*/*.cpp"
 )
 
-add_library(inference SHARED ${SOURCES})
-target_link_libraries(inference
+add_library(inference-object OBJECT ${SOURCES})
+target_link_libraries(inference-object
     LINK_PUBLIC sc-machine::sc-memory
     LINK_PUBLIC sc-machine::sc-agents-common
 )
-target_include_directories(inference
+target_include_directories(inference-object
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib/src
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/include>
     PUBLIC $<INSTALL_INTERFACE:include>
@@ -20,13 +20,18 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+add_library(inference SHARED)
+target_link_libraries(inference 
+    LINK_PUBLIC inference-object
+)
+
 file(GLOB SOURCES CONFIGURE_DEPENDS
     "module/*.hpp" "module/*.cpp"
 )
 
 add_library(inference-module SHARED ${SOURCES})
 target_link_libraries(inference-module
-    LINK_PUBLIC inference
+    LINK_PUBLIC inference-object
 )
 target_include_directories(inference-module
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/module


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/scl-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix dynamic loading of inference module by restructuring CMake setup and updating installation paths.
> 
>   - **CMake Configuration**:
>     - Move Windows OS check earlier in `CMakeLists.txt`.
>     - Create `inference-object` as an OBJECT library in `inference-module/CMakeLists.txt`.
>     - Link `inference-object` to `inference` and `inference-module` as SHARED libraries.
>   - **Installation**:
>     - Update `install.cmake` to install `inference-object` and `inference`.
>     - Adjust installation paths for `inference-module` and `solution-module` to `${CMAKE_INSTALL_LIBDIR}/extensions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fscl-machine&utm_source=github&utm_medium=referral)<sup> for 29f4396b43a3da2ae669443e9195446abe7c8851. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->